### PR TITLE
Fix LCD tests interdependency

### DIFF
--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -67,20 +68,22 @@ import (
 
 // makePathname creates a unique pathname for each test. It will panic if it
 // cannot get the current working directory.
-func makePathname() string {
+func makePathname() (string, string) {
 	p, err := os.Getwd()
 	if err != nil {
 		panic(err)
 	}
 
+	uniq := fmt.Sprintf("%d", rand.Int()%1000000)
+
 	sep := string(filepath.Separator)
-	return strings.Replace(p, sep, "_", -1)
+	return strings.Replace(p, sep, "_", -1), uniq
 }
 
 // GetConfig returns a Tendermint config for the test cases.
 func GetConfig() *tmcfg.Config {
-	pathname := makePathname()
-	config := tmcfg.ResetTestRoot(pathname)
+	pathname, uniq := makePathname()
+	config := tmcfg.ResetTestRoot(pathname, uniq)
 
 	tmAddr, _, err := server.FreeTCPAddr()
 	if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

In `InitializeTestLCD` chainID for each test became unique so LCD verifier stores commits in a different space. I had to modify https://github.com/tendermint/tendermint/blob/master/config/toml.go#L319 to take additional parameter for chainID(which is fixed as `tendermint_test` currently).

`CLIContext` originally stored single verifier as a global constant. Since each verifier is parameterized by chainID, it is modified as a `map[chainID string]tmlite.Verifier` to be able to work for multiple chains in a single process. 

LCD test is now passing but `toml.go` should be modified first to merge this PR.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
